### PR TITLE
Don't count key values

### DIFF
--- a/ShipLoot/Patches/HudManagerPatcher.cs
+++ b/ShipLoot/Patches/HudManagerPatcher.cs
@@ -59,7 +59,7 @@ namespace ShipLoot.Patches
             // Get all objects that can be picked up from inside the ship. Also remove items which technically have
             // scrap value but don't actually add to your quota.
             var loot = ship.GetComponentsInChildren<GrabbableObject>()
-                .Where(obj => obj.name != "ClipboardManual" && obj.name != "StickyNoteItem").ToList();
+                .Where(obj => obj.name != "ClipboardManual" && obj.name != "StickyNoteItem" && obj.name != "Key(Clone)" && obj.name != "Key").ToList();
             ShipLoot.Log.LogDebug("Calculating total ship scrap value.");
             loot.Do(scrap => ShipLoot.Log.LogDebug($"{scrap.name} - ${scrap.scrapValue}"));
             return loot.Sum(scrap => scrap.scrapValue);


### PR DESCRIPTION
Right now, in-game key value is 3$, but selling them gives you 0$.

This pull request fixes mismatch between reported loot value and the **actual** value when selling.